### PR TITLE
Исправил сортировку карточек по длительности окупаемости

### DIFF
--- a/hamster_client.py
+++ b/hamster_client.py
@@ -32,8 +32,8 @@ def sorted_by_price(prepared):
     return sorted(prepared, key=lambda x: x["price"], reverse=False)
 
 
-def sorted_by_payback(prepared, balance):
-    return sorted(prepared, key=lambda x: x['price'] / (balance + x['profitPerHourDelta']), reverse=False)
+def sorted_by_payback(prepared, earn):
+    return sorted(prepared, key=lambda x: x['price'] / (earn + x['profitPerHourDelta']), reverse=False)
 
 
 def retry(func):
@@ -186,7 +186,7 @@ class HamsterClient(Session):
                 - без ожидания перезарядки
             2. Сортируем по профитности на каждую потраченную монету
         """
-        methods = dict(payback=lambda upgrades: sorted_by_payback(upgrades, self.balance),
+        methods = dict(payback=lambda upgrades: sorted_by_payback(upgrades, self.state['earnPassivePerHour']),
                        price=sorted_by_price,
                        profit=sorted_by_profit,
                        profitness=sorted_by_profitness)

--- a/hamster_client.py
+++ b/hamster_client.py
@@ -32,8 +32,8 @@ def sorted_by_price(prepared):
     return sorted(prepared, key=lambda x: x["price"], reverse=False)
 
 
-def sorted_by_payback(prepared):
-    return sorted(prepared, key=lambda x: x['price'] / x['profitPerHourDelta'], reverse=False)
+def sorted_by_payback(prepared, balance):
+    return sorted(prepared, key=lambda x: x['price'] / (balance + x['profitPerHourDelta']), reverse=False)
 
 
 def retry(func):
@@ -186,7 +186,7 @@ class HamsterClient(Session):
                 - без ожидания перезарядки
             2. Сортируем по профитности на каждую потраченную монету
         """
-        methods = dict(payback=sorted_by_payback,
+        methods = dict(payback=lambda upgrades: sorted_by_payback(upgrades, self.balance),
                        price=sorted_by_price,
                        profit=sorted_by_profit,
                        profitness=sorted_by_profitness)
@@ -203,7 +203,7 @@ class HamsterClient(Session):
                     item.pop('condition')
                 prepared.append(item)
         if prepared:
-            sorted_items = [i for i in methods[method](prepared)] # if i['price'] <= self.balance]
+            sorted_items = methods[method](prepared) # if i['price'] <= self.balance]
             return sorted_items
         return []
 


### PR DESCRIPTION
ЗВЧ - заработок в час

---

Текущая реализация говорит, что карточки `notcoin_listing` (стоимость 20к, профит 2.4к) и `ceo_21m` (стоимость 2.5к, профит 300) равноценны.

```
('notcoin_listing', 8.333333333333334)
('ceo_21m', 8.333333333333334)
```

Предположим, что на текущий момент у нас ЗВЧ 2200. Купив карточку `ceo_21m`, ЗВЧ станет 2500 (2200 + 300) и стоимость карточки (2500) мы отобьём за `1 час`. В то время как после покупки карточки `notcoin_listing` ЗВЧ станет 4600 (2200 + 2400) и карточка окупиться лишь через (20 000 / 4 600) `4.3478... часа`.

> **Исходя из этого мы можем сделать вывод, что карточка `ceo_21m` окупится быстрее на 3 часа.**

Хорошо, но что если у нас ЗВЧ отличный от примера?

> Построим график, где `x` - наш текущий ЗВЧ, а `y`- длительность окупа карточки (в часах).
> Из примера выше мы можем понять, по какой формуле будем строить график (см. ниже)
> ![image](https://github.com/TotalAwesome/HamsterKombatFarmer/assets/64022121/11d76973-0471-4ac1-9e09-15cce8cb5077)
> ![image](https://github.com/TotalAwesome/HamsterKombatFarmer/assets/64022121/16237627-a24f-4530-8b97-68cf0d4a51fe) (`y` - меньше (ниже) — лучше)
> 
> На графике мы видим, что у карточки `ceo_21m` (красный) примерно до 3 ЗВЧ длительность окупаемости практически не меняется, но после — длительность стремительно падает вниз. В то время как у карточки `notcoin_listing` (зелёный) это падание начинается примерно на 30 ЗВЧ.

Исходя из графика мы можем окончательно сделать вывод, что карточка `ceo_21m` выгоднее `notcoin_listing`. (с теми данными, что изначально даны; на 1 уровне).

---

Потыкать график — https://www.desmos.com/calculator/f2yfdjyjuz